### PR TITLE
Changing postgres dashboard to CNPG

### DIFF
--- a/dashboards/postgres.json
+++ b/dashboards/postgres.json
@@ -1864,7 +1864,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(5, rate(pg_stat_statements_block_read_seconds_total{namespace=\"$namespace\", pod=\"$instance\"}[15m])) * on(queryid, pod) group_left(query) pg_stat_statements_query_id",
+          "expr": "topk(5, rate(cnpg_pg_stat_statements_block_read_seconds_total{namespace=\"$namespace\", pod=\"$instance\"}[15m])) * on(queryid, pod) group_left(query) cnpg_pg_stat_statements_query_id",
           "format": "time_series",
           "instant": false,
           "legendFormat": "{{query}}",
@@ -1872,7 +1872,7 @@
           "refId": "A"
         }
       ],
-      "title": "Top queries by seconds spent reading (NOT WORKING)",
+      "title": "Top queries by seconds spent reading",
       "type": "timeseries"
     },
     {
@@ -1951,7 +1951,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "topk(5, rate(pg_stat_statements_block_read_seconds_total{namespace=\"$namespace\", pod=\"$instance\"}[15m])) * on(queryid, pod) group_left(query) pg_stat_statements_query_id",
+          "expr": "topk(5, rate(cnpg_pg_stat_statements_block_read_seconds_total{namespace=\"$namespace\", pod=\"$instance\"}[15m])) * on(queryid, pod) group_left(query) cnpg_pg_stat_statements_query_id",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -1959,7 +1959,7 @@
           "refId": "A"
         }
       ],
-      "title": "Top queries by seconds spent reading (NOT WORKING)",
+      "title": "Top queries by seconds spent reading",
       "transformations": [
         {
           "id": "organize",
@@ -2080,7 +2080,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "topk(10, rate( pg_stat_statements_seconds_total{namespace=\"$namespace\", pod=\"$instance\"} [5m])) * on(queryid, pod) group_left(query) pg_stat_statements_query_id",
+          "expr": "topk(10, rate( cnpg_pg_stat_statements_seconds_total{namespace=\"$namespace\", pod=\"$instance\"} [5m])) * on(queryid, pod) group_left(query) cnpg_pg_stat_statements_query_id",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2089,7 +2089,7 @@
           "refId": "A"
         }
       ],
-      "title": "Top queries by time used (NOT WORKING)",
+      "title": "Top queries by time used",
       "type": "timeseries"
     },
     {
@@ -2168,7 +2168,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "topk(10, rate( pg_stat_statements_seconds_total{namespace=\"$namespace\", pod=\"$instance\"} [5m])) * on(queryid, pod) group_left(query) pg_stat_statements_query_id",
+          "expr": "topk(10, rate( cnpg_pg_stat_statements_seconds_total{namespace=\"$namespace\", pod=\"$instance\"} [5m])) * on(queryid, pod) group_left(query) cnpg_pg_stat_statements_query_id",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -2176,7 +2176,7 @@
           "refId": "A"
         }
       ],
-      "title": "Top queries by time used (NOT WORKING)",
+      "title": "Top queries by time used",
       "transformations": [
         {
           "id": "organize",
@@ -2295,14 +2295,14 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, rate(pg_stat_statements_block_write_seconds_total{namespace=\"$namespace\", pod=\"$instance\"}[5m])) * on(queryid, pod) group_left(query) pg_stat_statements_query_id",
+          "expr": "topk(10, rate(cnpg_pg_stat_statements_block_write_seconds_total{namespace=\"$namespace\", pod=\"$instance\"}[5m])) * on(queryid, pod) group_left(query) cnpg_pg_stat_statements_query_id",
           "instant": false,
           "legendFormat": "{{query}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Top queries by time spent writing (NOT WORKING)",
+      "title": "Top queries by time spent writing",
       "type": "timeseries"
     },
     {
@@ -2386,7 +2386,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "topk(10, rate(pg_stat_statements_block_write_seconds_total{namespace=\"$namespace\", pod=\"$instance\"}[5m])) * on(queryid, pod) group_left(query) pg_stat_statements_query_id",
+          "expr": "topk(10, rate(cnpg_pg_stat_statements_block_write_seconds_total{namespace=\"$namespace\", pod=\"$instance\"}[5m])) * on(queryid, pod) group_left(query) cnpg_pg_stat_statements_query_id",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -2394,7 +2394,7 @@
           "refId": "A"
         }
       ],
-      "title": "Top queries by time spent writing (NOT WORKING)",
+      "title": "Top queries by time spent writing",
       "transformations": [
         {
           "id": "organize",
@@ -2512,14 +2512,14 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, rate(pg_stat_statements_calls_total{namespace=\"$namespace\", pod=\"$instance\"}[15m])) * on(queryid, pod) group_left(query) pg_stat_statements_query_id",
+          "expr": "topk(10, rate(cnpg_pg_stat_statements_calls_total{namespace=\"$namespace\", pod=\"$instance\"}[15m])) * on(queryid, pod) group_left(query) cnpg_pg_stat_statements_query_id",
           "instant": false,
           "legendFormat": "{{query}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Top queries by calls (NOT WORKING)",
+      "title": "Top queries by calls",
       "type": "timeseries"
     },
     {
@@ -2590,7 +2590,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "topk(10, rate(pg_stat_statements_calls_total{namespace=\"$namespace\", pod=\"$instance\"}[15m])) * on(queryid, pod) group_left(query) pg_stat_statements_query_id",
+          "expr": "topk(10, rate(cnpg_pg_stat_statements_calls_total{namespace=\"$namespace\", pod=\"$instance\"}[15m])) * on(queryid, pod) group_left(query) cnpg_pg_stat_statements_query_id",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -2598,7 +2598,7 @@
           "refId": "A"
         }
       ],
-      "title": "Top queries by calls (NOT WORKING)",
+      "title": "Top queries by calls",
       "transformations": [
         {
           "id": "organize",

--- a/dashboards/postgres.json
+++ b/dashboards/postgres.json
@@ -1674,6 +1674,336 @@
         "x": 0,
         "y": 13
       },
+      "id": 93,
+      "panels": [],
+      "title": "WAL archiving",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of WAL files that have been successfully archived",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "green",
+                "value": 3
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 14
+      },
+      "id": 94,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "cnpg_pg_stat_archiver_archived_count{pod=\"${instance}\"}",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Archived",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Time since the last successful archival operation",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 600
+              },
+              {
+                "color": "red",
+                "value": 1800
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 14
+      },
+      "id": 96,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "cnpg_pg_stat_archiver_seconds_since_last_archival{pod=\"${instance}\"}",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Time since last archive",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of failed attempts for archiving WAL files",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 3
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 14
+      },
+      "id": 95,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "cnpg_pg_stat_archiver_failed_count{pod=\"${instance}\"}",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Failed",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Time since the last failed archival operation",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "-1": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "No failures"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 600
+              },
+              {
+                "color": "green",
+                "value": 1800
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 14
+      },
+      "id": 97,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "cnpg_pg_stat_archiver_seconds_since_last_failure{pod=\"${instance}\"}",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Time since last failure",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
       "id": 73,
       "panels": [],
       "title": "Query Insights Light",
@@ -1745,7 +2075,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 14
+        "y": 20
       },
       "id": 72,
       "maxDataPoints": 50,
@@ -1839,7 +2169,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 14
+        "y": 20
       },
       "id": 82,
       "maxDataPoints": 50,
@@ -1961,7 +2291,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 22
+        "y": 28
       },
       "id": 71,
       "options": {
@@ -2056,7 +2386,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 22
+        "y": 28
       },
       "id": 83,
       "maxDataPoints": 50,
@@ -2178,7 +2508,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 30
+        "y": 36
       },
       "id": 74,
       "options": {
@@ -2270,7 +2600,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 30
+        "y": 36
       },
       "id": 84,
       "maxDataPoints": 50,
@@ -2391,7 +2721,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 38
+        "y": 44
       },
       "id": 75,
       "options": {
@@ -2470,7 +2800,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 38
+        "y": 44
       },
       "id": 85,
       "maxDataPoints": 50,
@@ -2591,7 +2921,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 46
+        "y": 52
       },
       "id": 76,
       "options": {
@@ -2631,7 +2961,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 54
+        "y": 60
       },
       "id": 30,
       "panels": [],
@@ -2705,7 +3035,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 55
+        "y": 61
       },
       "id": 1,
       "options": {
@@ -2813,7 +3143,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 55
+        "y": 61
       },
       "id": 60,
       "options": {
@@ -2930,7 +3260,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 55
+        "y": 61
       },
       "id": 3,
       "options": {
@@ -3035,7 +3365,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 62
+        "y": 68
       },
       "id": 5,
       "options": {
@@ -3140,7 +3470,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 62
+        "y": 68
       },
       "id": 6,
       "options": {
@@ -3245,7 +3575,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 62
+        "y": 68
       },
       "id": 8,
       "options": {
@@ -3352,7 +3682,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 69
+        "y": 75
       },
       "id": 14,
       "options": {
@@ -3458,7 +3788,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 69
+        "y": 75
       },
       "id": 4,
       "options": {
@@ -3562,7 +3892,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 69
+        "y": 75
       },
       "id": 7,
       "options": {
@@ -3668,7 +3998,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 76
+        "y": 82
       },
       "id": 62,
       "options": {
@@ -3770,7 +4100,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 76
+        "y": 82
       },
       "id": 64,
       "options": {
@@ -3919,7 +4249,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 76
+        "y": 82
       },
       "id": 66,
       "options": {
@@ -4035,7 +4365,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 83
+        "y": 89
       },
       "id": 68,
       "options": {
@@ -4078,7 +4408,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 90
+        "y": 96
       },
       "id": 89,
       "panels": [],
@@ -4151,7 +4481,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 91
+        "y": 97
       },
       "id": 87,
       "options": {
@@ -4250,7 +4580,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 91
+        "y": 97
       },
       "id": 90,
       "options": {
@@ -4348,7 +4678,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 91
+        "y": 97
       },
       "id": 91,
       "options": {
@@ -4517,6 +4847,6 @@
   "timezone": "default",
   "title": "Postgres overview - CNPG",
   "uid": "postgres",
-  "version": 15,
+  "version": 16,
   "weekStart": ""
 }

--- a/dashboards/postgres.json
+++ b/dashboards/postgres.json
@@ -1351,7 +1351,7 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 12,
+        "w": 8,
         "x": 0,
         "y": 6
       },
@@ -1464,8 +1464,8 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 12,
-        "x": 12,
+        "w": 8,
+        "x": 8,
         "y": 6
       },
       "id": 24,
@@ -1594,9 +1594,9 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 12,
-        "x": 0,
-        "y": 13
+        "w": 8,
+        "x": 16,
+        "y": 6
       },
       "id": 86,
       "options": {
@@ -1672,7 +1672,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 20
+        "y": 13
       },
       "id": 73,
       "panels": [],
@@ -1745,7 +1745,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 21
+        "y": 14
       },
       "id": 72,
       "maxDataPoints": 50,
@@ -1839,7 +1839,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 21
+        "y": 14
       },
       "id": 82,
       "maxDataPoints": 50,
@@ -1961,7 +1961,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 29
+        "y": 22
       },
       "id": 71,
       "options": {
@@ -2056,7 +2056,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 29
+        "y": 22
       },
       "id": 83,
       "maxDataPoints": 50,
@@ -2146,6 +2146,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -2177,7 +2178,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 37
+        "y": 30
       },
       "id": 74,
       "options": {
@@ -2193,7 +2194,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -2224,12 +2225,15 @@
           "custom": {
             "align": "auto",
             "cellOptions": {
-              "type": "auto",
-              "wrapText": true
+              "type": "auto"
             },
             "filterable": false,
+            "footer": {
+              "reducers": []
+            },
             "inspect": false,
-            "minWidth": 50
+            "minWidth": 50,
+            "wrapText": true
           },
           "mappings": [],
           "thresholds": {
@@ -2266,24 +2270,16 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 37
+        "y": 30
       },
       "id": 84,
       "maxDataPoints": 50,
       "options": {
         "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
         "showHeader": false,
         "sortBy": []
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -2364,6 +2360,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -2394,7 +2391,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 45
+        "y": 38
       },
       "id": 75,
       "options": {
@@ -2410,7 +2407,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -2441,12 +2438,15 @@
           "custom": {
             "align": "auto",
             "cellOptions": {
-              "type": "auto",
-              "wrapText": true
+              "type": "auto"
             },
             "filterable": false,
+            "footer": {
+              "reducers": []
+            },
             "inspect": false,
-            "minWidth": 50
+            "minWidth": 50,
+            "wrapText": true
           },
           "mappings": [],
           "thresholds": {}
@@ -2470,24 +2470,16 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 45
+        "y": 38
       },
       "id": 85,
       "maxDataPoints": 50,
       "options": {
         "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
         "showHeader": false,
         "sortBy": []
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -2568,6 +2560,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -2598,7 +2591,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 53
+        "y": 46
       },
       "id": 76,
       "options": {
@@ -2614,7 +2607,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -2638,7 +2631,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 61
+        "y": 54
       },
       "id": 30,
       "panels": [],
@@ -2679,6 +2672,7 @@
               "type": "linear"
             },
             "showPoints": "always",
+            "showValues": false,
             "spanNulls": true,
             "stacking": {
               "group": "A",
@@ -2711,7 +2705,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 62
+        "y": 55
       },
       "id": 1,
       "options": {
@@ -2732,7 +2726,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -2787,6 +2781,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -2818,7 +2813,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 62
+        "y": 55
       },
       "id": 60,
       "options": {
@@ -2839,7 +2834,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -2901,6 +2896,324 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 55
+      },
+      "id": 3,
+      "options": {
+        "dataLinks": [],
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "cnpg_pg_locks_count{datname=~\"$datname\", pod=\"$instance\", mode=~\"$mode\"}",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{datname}},{{mode}}",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "title": "Lock tables",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 62
+      },
+      "id": 5,
+      "options": {
+        "dataLinks": [],
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "cnpg_pg_stat_database_tup_fetched{datname=~\"$datname\", pod=\"$instance\"}",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{datname}}",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "title": "Fetch data (SELECT)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 62
+      },
+      "id": 6,
+      "options": {
+        "dataLinks": [],
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "cnpg_pg_stat_database_tup_inserted{datname=~\"$datname\", pod=\"$instance\"}",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{datname}}",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "title": "Insert data",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -2953,7 +3266,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -3007,6 +3320,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -3039,320 +3353,6 @@
         "w": 8,
         "x": 0,
         "y": 69
-      },
-      "id": 5,
-      "options": {
-        "dataLinks": [],
-        "legend": {
-          "calcs": [
-            "mean",
-            "lastNotNull",
-            "sum"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.1.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "cnpg_pg_stat_database_tup_fetched{datname=~\"$datname\", pod=\"$instance\"}",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{datname}}",
-          "refId": "A",
-          "step": 2
-        }
-      ],
-      "title": "Fetch data (SELECT)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 8,
-        "y": 69
-      },
-      "id": 6,
-      "options": {
-        "dataLinks": [],
-        "legend": {
-          "calcs": [
-            "mean",
-            "lastNotNull",
-            "sum"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.1.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "cnpg_pg_stat_database_tup_inserted{datname=~\"$datname\", pod=\"$instance\"}",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{datname}}",
-          "refId": "A",
-          "step": 2
-        }
-      ],
-      "title": "Insert data",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "decimals": 0,
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 16,
-        "y": 69
-      },
-      "id": 3,
-      "options": {
-        "dataLinks": [],
-        "legend": {
-          "calcs": [
-            "mean",
-            "lastNotNull",
-            "sum"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.1.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "cnpg_pg_locks_count{datname=~\"$datname\", pod=\"$instance\", mode=~\"$mode\"}",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{datname}},{{mode}}",
-          "refId": "A",
-          "step": 2
-        }
-      ],
-      "title": "Lock tables",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 0,
-        "y": 76
       },
       "id": 14,
       "options": {
@@ -3373,7 +3373,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -3425,6 +3425,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -3457,7 +3458,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 76
+        "y": 69
       },
       "id": 4,
       "options": {
@@ -3477,7 +3478,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -3529,6 +3530,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -3560,7 +3562,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 76
+        "y": 69
       },
       "id": 7,
       "options": {
@@ -3581,7 +3583,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -3633,6 +3635,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -3665,7 +3668,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 83
+        "y": 76
       },
       "id": 62,
       "options": {
@@ -3684,7 +3687,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -3735,6 +3738,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -3766,7 +3770,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 83
+        "y": 76
       },
       "id": 64,
       "options": {
@@ -3787,7 +3791,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -3882,6 +3886,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -3914,7 +3919,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 83
+        "y": 76
       },
       "id": 66,
       "options": {
@@ -3934,7 +3939,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -3997,6 +4002,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -4029,7 +4035,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 90
+        "y": 83
       },
       "id": 68,
       "options": {
@@ -4049,7 +4055,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -4064,6 +4070,316 @@
         }
       ],
       "title": "Temp File (Bytes)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 90
+      },
+      "id": 89,
+      "panels": [],
+      "title": "Replication",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Replicas actively streaming updates",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 4,
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 91
+      },
+      "id": 87,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "cnpg_pg_replication_streaming_replicas{pod=\"${instance}\"}",
+          "instant": false,
+          "legendFormat": "replicas",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Streaming replicas",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 4,
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 91
+      },
+      "id": 90,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "cnpg_pg_replication_slots_active{pod=\"${instance}\"}",
+          "instant": false,
+          "legendFormat": "replicas",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Active replica slots",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Replication lag in seconds",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 91
+      },
+      "id": 91,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "cnpg_pg_replication_lag{pod=\"${instance}\"}",
+          "instant": false,
+          "legendFormat": "lag",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Lag",
       "type": "timeseries"
     }
   ],
@@ -4201,6 +4517,6 @@
   "timezone": "default",
   "title": "Postgres overview - CNPG",
   "uid": "postgres",
-  "version": 4,
+  "version": 15,
   "weekStart": ""
 }

--- a/dashboards/postgres.json
+++ b/dashboards/postgres.json
@@ -2100,7 +2100,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(5, rate(cnpg_pg_stat_statements_block_read_seconds_total{namespace=\"$namespace\", pod=\"$instance\"}[15m])) * on(queryid, pod) group_left(query) cnpg_pg_stat_statements_query_id",
+          "expr": "topk(5, rate(cnpg_pg_stat_statements_block_read_seconds_total{namespace=\"$namespace\", pod=\"$instance\"}[15m])) * on(queryid, pod) group_left(query) cnpg_pg_stat_statements_queries_value",
           "format": "time_series",
           "instant": false,
           "legendFormat": "{{query}}",
@@ -2154,12 +2154,12 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "query"
+              "options": "Value"
             },
             "properties": [
               {
                 "id": "custom.width",
-                "value": 711
+                "value": 100
               }
             ]
           }
@@ -2187,7 +2187,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "topk(5, rate(cnpg_pg_stat_statements_block_read_seconds_total{namespace=\"$namespace\", pod=\"$instance\"}[15m])) * on(queryid, pod) group_left(query) cnpg_pg_stat_statements_query_id",
+          "expr": "topk(5, rate(cnpg_pg_stat_statements_block_read_seconds_total{namespace=\"$namespace\", pod=\"$instance\"}[15m])) * on(queryid, pod) group_left(query) cnpg_pg_stat_statements_queries_value",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -2204,6 +2204,7 @@
               "Time": true,
               "app": true,
               "cluster_name": true,
+              "k8s_cluster_name": true,
               "container": true,
               "datname": true,
               "endpoint": true,
@@ -2316,7 +2317,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "topk(10, rate( cnpg_pg_stat_statements_seconds_total{namespace=\"$namespace\", pod=\"$instance\"} [5m])) * on(queryid, pod) group_left(query) cnpg_pg_stat_statements_query_id",
+          "expr": "topk(10, rate( cnpg_pg_stat_statements_seconds_total{namespace=\"$namespace\", pod=\"$instance\"} [5m])) * on(queryid, pod) group_left(query) cnpg_pg_stat_statements_queries_value",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2371,12 +2372,12 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "query"
+              "options": "Value"
             },
             "properties": [
               {
                 "id": "custom.width",
-                "value": 711
+                "value": 100
               }
             ]
           }
@@ -2404,7 +2405,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "topk(10, rate( cnpg_pg_stat_statements_seconds_total{namespace=\"$namespace\", pod=\"$instance\"} [5m])) * on(queryid, pod) group_left(query) cnpg_pg_stat_statements_query_id",
+          "expr": "topk(10, rate( cnpg_pg_stat_statements_seconds_total{namespace=\"$namespace\", pod=\"$instance\"} [5m])) * on(queryid, pod) group_left(query) cnpg_pg_stat_statements_queries_value",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -2421,6 +2422,7 @@
               "Time": true,
               "app": true,
               "cluster_name": true,
+              "k8s_cluster_name": true,
               "container": true,
               "datname": true,
               "endpoint": true,
@@ -2532,7 +2534,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, rate(cnpg_pg_stat_statements_block_write_seconds_total{namespace=\"$namespace\", pod=\"$instance\"}[5m])) * on(queryid, pod) group_left(query) cnpg_pg_stat_statements_query_id",
+          "expr": "topk(10, rate(cnpg_pg_stat_statements_block_write_seconds_total{namespace=\"$namespace\", pod=\"$instance\"}[5m])) * on(queryid, pod) group_left(query) cnpg_pg_stat_statements_queries_value",
           "instant": false,
           "legendFormat": "{{query}}",
           "range": true,
@@ -2585,12 +2587,12 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "query"
+              "options": "Value"
             },
             "properties": [
               {
                 "id": "custom.width",
-                "value": 711
+                "value": 100
               }
             ]
           }
@@ -2618,7 +2620,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "topk(10, rate(cnpg_pg_stat_statements_block_write_seconds_total{namespace=\"$namespace\", pod=\"$instance\"}[5m])) * on(queryid, pod) group_left(query) cnpg_pg_stat_statements_query_id",
+          "expr": "topk(10, rate(cnpg_pg_stat_statements_block_write_seconds_total{namespace=\"$namespace\", pod=\"$instance\"}[5m])) * on(queryid, pod) group_left(query) cnpg_pg_stat_statements_queries_value",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -2635,6 +2637,7 @@
               "Time": true,
               "app": true,
               "cluster_name": true,
+              "k8s_cluster_name": true,
               "container": true,
               "datname": true,
               "endpoint": true,
@@ -2745,7 +2748,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, rate(cnpg_pg_stat_statements_calls_total{namespace=\"$namespace\", pod=\"$instance\"}[15m])) * on(queryid, pod) group_left(query) cnpg_pg_stat_statements_query_id",
+          "expr": "topk(10, rate(cnpg_pg_stat_statements_calls_total{namespace=\"$namespace\", pod=\"$instance\"}[15m])) * on(queryid, pod) group_left(query) cnpg_pg_stat_statements_queries_value",
           "instant": false,
           "legendFormat": "{{query}}",
           "range": true,
@@ -2785,12 +2788,12 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "query"
+              "options": "Value"
             },
             "properties": [
               {
                 "id": "custom.width",
-                "value": 711
+                "value": 100
               }
             ]
           }
@@ -2818,7 +2821,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "topk(10, rate(cnpg_pg_stat_statements_calls_total{namespace=\"$namespace\", pod=\"$instance\"}[15m])) * on(queryid, pod) group_left(query) cnpg_pg_stat_statements_query_id",
+          "expr": "topk(10, rate(cnpg_pg_stat_statements_calls_total{namespace=\"$namespace\", pod=\"$instance\"}[15m])) * on(queryid, pod) group_left(query) cnpg_pg_stat_statements_queries_value",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -2835,6 +2838,7 @@
               "Time": true,
               "app": true,
               "cluster_name": true,
+              "k8s_cluster_name": true,
               "container": true,
               "datname": true,
               "endpoint": true,

--- a/dashboards/postgres.json
+++ b/dashboards/postgres.json
@@ -2716,14 +2716,14 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, pg_stat_activity_max_tx_duration{namespace=\"$namespace\", pod=\"$instance\"})",
+          "expr": "topk(10, cnpg_pg_stat_activity_max_tx_duration{namespace=\"$namespace\", pod=\"$instance\"})",
           "instant": false,
           "legendFormat": "{{state}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Max transaction duration (NOT WORKING)",
+      "title": "Max transaction duration",
       "type": "timeseries"
     },
     {
@@ -2834,7 +2834,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "pg_stat_activity_count{datname=~\"$datname\", pod=\"$instance\", state=\"active\"}",
+          "expr": "cnpg_pg_stat_activity_count{datname=~\"$datname\", pod=\"$instance\", state=\"active\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -2844,7 +2844,7 @@
           "step": 2
         }
       ],
-      "title": "Active sessions (NOT WORKING)",
+      "title": "Active sessions",
       "type": "timeseries"
     },
     {
@@ -3578,7 +3578,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "pg_stat_activity_count{datname=~\"$datname\", pod=\"$instance\", state=~\"idle|idle in transaction|idle in transaction (aborted)\"}",
+          "expr": "cnpg_pg_stat_activity_count{datname=~\"$datname\", pod=\"$instance\", state=~\"idle|idle in transaction|idle in transaction (aborted)\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}, s: {{state}}",
@@ -3586,7 +3586,7 @@
           "step": 2
         }
       ],
-      "title": "Idle sessions (NOT WORKING)",
+      "title": "Idle sessions",
       "type": "timeseries"
     },
     {

--- a/dashboards/postgres.json
+++ b/dashboards/postgres.json
@@ -3370,7 +3370,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "pg_locks_count{datname=~\"$datname\", pod=\"$instance\", mode=~\"$mode\"}",
+          "expr": "cnpg_pg_locks_count{datname=~\"$datname\", pod=\"$instance\", mode=~\"$mode\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}},{{mode}}",
@@ -3378,7 +3378,7 @@
           "step": 2
         }
       ],
-      "title": "Lock tables (NOT WORKING)",
+      "title": "Lock tables",
       "type": "timeseries"
     },
     {

--- a/dashboards/postgres.json
+++ b/dashboards/postgres.json
@@ -1622,7 +1622,7 @@
           "editorMode": "code",
           "expr": "kubelet_volume_stats_used_bytes{persistentvolumeclaim=\"$instance\"}",
           "instant": false,
-          "legendFormat": "usage",
+          "legendFormat": "total",
           "range": true,
           "refId": "A"
         },
@@ -1649,6 +1649,18 @@
           "legendFormat": "capacity",
           "range": true,
           "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "cnpg_pg_database_size_bytes{pod=\"$instance\"}",
+          "instant": false,
+          "legendFormat": "{{datname}}",
+          "range": true,
+          "refId": "D"
         }
       ],
       "title": "Disk Usage",

--- a/dashboards/postgres.json
+++ b/dashboards/postgres.json
@@ -1283,7 +1283,7 @@
       },
       "id": 34,
       "panels": [],
-      "title": "General Counters, CPU, Memory and File Descriptor Stats",
+      "title": "General Counters, CPU, and Memory Stats",
       "type": "row"
     },
     {
@@ -1664,112 +1664,6 @@
         }
       ],
       "title": "Disk Usage",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Number of open file descriptors",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 13
-      },
-      "id": 26,
-      "options": {
-        "dataLinks": [],
-        "legend": {
-          "calcs": [
-            "mean",
-            "lastNotNull",
-            "max",
-            "min"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "process_open_fds{pod=\"$instance\"}",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "Open FD",
-          "refId": "A"
-        }
-      ],
-      "title": "Open File Descriptors (NOT WORKING)",
       "type": "timeseries"
     },
     {

--- a/dashboards/postgres.json
+++ b/dashboards/postgres.json
@@ -1,4 +1,20 @@
 {
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
   "description": "This dashboard works with postgres_exporter for prometheus",
   "editable": false,
   "fiscalYearStartMonth": 0,
@@ -32,12 +48,12 @@
             {
               "options": {
                 "0": {
-                  "index": 1,
-                  "text": "Yes"
-                },
-                "1": {
                   "index": 0,
                   "text": "No"
+                },
+                "1": {
+                  "index": 1,
+                  "text": "Yes"
                 }
               },
               "type": "value"
@@ -47,11 +63,11 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "yellow",
                 "value": 0
               },
               {
-                "color": "yellow",
+                "color": "green",
                 "value": 1
               }
             ]
@@ -83,7 +99,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -92,7 +108,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "pg_replication_is_replica{namespace=\"$namespace\", pod=\"$instance\"}",
+          "expr": "cnpg_pg_replication_streaming_replicas{namespace=\"$namespace\", pod=\"$instance\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -165,18 +181,18 @@
         "textMode": "name",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "pg_static{pod=\"$instance\"}",
+          "expr": "cnpg_collector_postgres_version{pod=\"$instance\"}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
-          "legendFormat": "{{short_version}}",
+          "legendFormat": "{{full}}",
           "refId": "A"
         }
       ],
@@ -233,7 +249,7 @@
         "textMode": "value",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -241,7 +257,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "(time() - process_start_time_seconds{pod=\"$instance\"}) / 3600",
+          "expr": "(time() - cnpg_pg_postmaster_start_time{pod=\"$instance\"}) / 3600",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -311,14 +327,14 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "SUM(pg_stat_database_tup_inserted{datname=~\"$datname\", pod=\"$instance\"})",
+          "expr": "SUM(cnpg_pg_stat_database_tup_inserted{datname=~\"$datname\", pod=\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -388,14 +404,14 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "SUM(pg_stat_database_tup_fetched{datname=~\"$datname\", pod=\"$instance\"})",
+          "expr": "SUM(cnpg_pg_stat_database_tup_fetched{datname=~\"$datname\", pod=\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -465,14 +481,14 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "SUM(pg_stat_database_tup_updated{datname=~\"$datname\", pod=\"$instance\"})",
+          "expr": "SUM(cnpg_pg_stat_database_tup_updated{datname=~\"$datname\", pod=\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -542,14 +558,14 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "pg_settings_max_connections{pod=\"$instance\"}",
+          "expr": "cnpg_pg_settings_setting{name=\"max_connections\",pod=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -631,14 +647,14 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "pg_settings_shared_buffers_bytes{pod=\"$instance\"}",
+          "expr": "cnpg_pg_settings_setting{name=\"shared_buffers\",pod=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -707,14 +723,14 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "pg_settings_effective_cache_size_bytes{pod=\"$instance\"}",
+          "expr": "cnpg_pg_settings_setting{name=\"effective_cache_size\",pod=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -783,14 +799,14 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "pg_settings_maintenance_work_mem_bytes{pod=\"$instance\"}",
+          "expr": "cnpg_pg_settings_setting{name=\"maintenance_work_mem\",pod=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -859,14 +875,14 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "pg_settings_work_mem_bytes{pod=\"$instance\"}",
+          "expr": "cnpg_pg_settings_setting{name=\"work_mem\",pod=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "",
@@ -937,14 +953,14 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "pg_settings_max_wal_size_bytes{pod=\"$instance\"}",
+          "expr": "cnpg_pg_settings_setting{name=\"max_wal_size\",pod=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -1013,14 +1029,14 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "pg_settings_random_page_cost{pod=\"$instance\"}",
+          "expr": "cnpg_pg_settings_setting{name=\"random_page_cost\",pod=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -1089,14 +1105,14 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "pg_settings_seq_page_cost{pod=\"$instance\"}",
+          "expr": "cnpg_pg_settings_setting{name=\"seq_page_cost\",pod=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -1165,14 +1181,14 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "pg_settings_max_worker_processes{pod=\"$instance\"}",
+          "expr": "cnpg_pg_settings_setting{name=\"max_worker_processes\",pod=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -1241,14 +1257,14 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "pg_settings_max_parallel_workers{pod=\"$instance\"}",
+          "expr": "cnpg_pg_settings_setting{name=\"max_parallel_workers\",pod=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -1306,6 +1322,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1352,7 +1369,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -1373,7 +1390,6 @@
           },
           "editorMode": "code",
           "expr": "sum(kube_pod_container_resource_requests{container=\"postgres\", pod=\"$instance\", resource=\"cpu\"}) by (pod)",
-          "hide": false,
           "instant": false,
           "legendFormat": "request",
           "range": true,
@@ -1418,6 +1434,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1471,14 +1488,14 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "avg(rate(process_resident_memory_bytes{pod=\"$instance\"}[5m]))",
+          "expr": "avg(container_memory_rss{pod=\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Resident Mem",
@@ -1489,20 +1506,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "avg(rate(process_virtual_memory_bytes{pod=\"$instance\"}[5m]))",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "Virtual Mem",
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
           "editorMode": "code",
           "expr": "kube_pod_container_resource_limits{resource=\"memory\", pod=\"$instance\", container=\"postgres\"}",
-          "hide": false,
           "instant": false,
           "legendFormat": "Postgres Limit Mem",
           "range": true,
@@ -1514,8 +1519,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(rate(container_memory_usage_bytes{container=\"postgres\", pod=\"$instance\"}[5m]))",
-          "hide": false,
+          "expr": "avg(container_memory_usage_bytes{container=\"postgres\", pod=\"$instance\"})",
           "instant": false,
           "legendFormat": "Postgres Usage Mem",
           "range": true,
@@ -1530,7 +1534,6 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1561,6 +1564,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1608,7 +1612,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -1616,7 +1620,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "kubelet_volume_stats_used_bytes{persistentvolumeclaim=\"pgdata-$instance\"}",
+          "expr": "kubelet_volume_stats_used_bytes{persistentvolumeclaim=\"$instance\"}",
           "instant": false,
           "legendFormat": "usage",
           "range": true,
@@ -1628,8 +1632,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "kube_persistentvolumeclaim_resource_requests_storage_bytes{persistentvolumeclaim=\"pgdata-$instance\"}",
-          "hide": false,
+          "expr": "kube_persistentvolumeclaim_resource_requests_storage_bytes{persistentvolumeclaim=\"$instance\"}",
           "instant": false,
           "legendFormat": "request",
           "range": true,
@@ -1641,8 +1644,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=\"pgdata-$instance\"}",
-          "hide": false,
+          "expr": "kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=\"$instance\"}",
           "instant": false,
           "legendFormat": "capacity",
           "range": true,
@@ -1687,6 +1689,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1740,7 +1743,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -1754,7 +1757,7 @@
           "refId": "A"
         }
       ],
-      "title": "Open File Descriptors",
+      "title": "Open File Descriptors (NOT WORKING)",
       "type": "timeseries"
     },
     {
@@ -1804,6 +1807,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1852,7 +1856,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -1868,7 +1872,7 @@
           "refId": "A"
         }
       ],
-      "title": "Top queries by seconds spent reading",
+      "title": "Top queries by seconds spent reading (NOT WORKING)",
       "type": "timeseries"
     },
     {
@@ -1884,12 +1888,15 @@
           "custom": {
             "align": "auto",
             "cellOptions": {
-              "type": "auto",
-              "wrapText": true
+              "type": "auto"
             },
             "filterable": false,
+            "footer": {
+              "reducers": []
+            },
             "inspect": false,
-            "minWidth": 50
+            "minWidth": 50,
+            "wrapText": true
           },
           "mappings": [],
           "thresholds": {
@@ -1932,18 +1939,10 @@
       "maxDataPoints": 50,
       "options": {
         "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
         "showHeader": false,
         "sortBy": []
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -1960,7 +1959,7 @@
           "refId": "A"
         }
       ],
-      "title": "Top queries by seconds spent reading",
+      "title": "Top queries by seconds spent reading (NOT WORKING)",
       "transformations": [
         {
           "id": "organize",
@@ -2024,6 +2023,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -2071,7 +2071,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -2089,7 +2089,7 @@
           "refId": "A"
         }
       ],
-      "title": "Top queries by time used",
+      "title": "Top queries by time used (NOT WORKING)",
       "type": "timeseries"
     },
     {
@@ -2105,12 +2105,15 @@
           "custom": {
             "align": "auto",
             "cellOptions": {
-              "type": "auto",
-              "wrapText": true
+              "type": "auto"
             },
             "filterable": false,
+            "footer": {
+              "reducers": []
+            },
             "inspect": false,
-            "minWidth": 50
+            "minWidth": 50,
+            "wrapText": true
           },
           "mappings": [],
           "thresholds": {
@@ -2153,18 +2156,10 @@
       "maxDataPoints": 50,
       "options": {
         "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
         "showHeader": false,
         "sortBy": []
       },
-      "pluginVersion": "12.1.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -2181,7 +2176,7 @@
           "refId": "A"
         }
       ],
-      "title": "Top queries by time used",
+      "title": "Top queries by time used (NOT WORKING)",
       "transformations": [
         {
           "id": "organize",
@@ -2307,7 +2302,7 @@
           "refId": "A"
         }
       ],
-      "title": "Top queries by time spent writing",
+      "title": "Top queries by time spent writing (NOT WORKING)",
       "type": "timeseries"
     },
     {
@@ -2399,7 +2394,7 @@
           "refId": "A"
         }
       ],
-      "title": "Top queries by time spent writing",
+      "title": "Top queries by time spent writing (NOT WORKING)",
       "transformations": [
         {
           "id": "organize",
@@ -2524,7 +2519,7 @@
           "refId": "A"
         }
       ],
-      "title": "Top queries by calls",
+      "title": "Top queries by calls (NOT WORKING)",
       "type": "timeseries"
     },
     {
@@ -2603,7 +2598,7 @@
           "refId": "A"
         }
       ],
-      "title": "Top queries by calls",
+      "title": "Top queries by calls (NOT WORKING)",
       "transformations": [
         {
           "id": "organize",
@@ -2728,7 +2723,7 @@
           "refId": "A"
         }
       ],
-      "title": "Max transaction duration",
+      "title": "Max transaction duration (NOT WORKING)",
       "type": "timeseries"
     },
     {
@@ -2849,7 +2844,7 @@
           "step": 2
         }
       ],
-      "title": "Active sessions",
+      "title": "Active sessions (NOT WORKING)",
       "type": "timeseries"
     },
     {
@@ -2945,7 +2940,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "irate(pg_stat_database_xact_commit{pod=\"$instance\", datname=~\"$datname\"}[5m])",
+          "expr": "irate(cnpg_pg_stat_database_xact_commit{pod=\"$instance\", datname=~\"$datname\"}[5m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{datname}} commits",
@@ -2956,7 +2951,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "irate(pg_stat_database_xact_rollback{pod=\"$instance\", datname=~\"$datname\"}[5m])",
+          "expr": "irate(cnpg_pg_stat_database_xact_rollback{pod=\"$instance\", datname=~\"$datname\"}[5m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{datname}} rollbacks",
@@ -3060,7 +3055,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "pg_stat_database_tup_updated{datname=~\"$datname\", pod=\"$instance\"}",
+          "expr": "cnpg_pg_stat_database_tup_updated{datname=~\"$datname\", pod=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -3165,7 +3160,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "pg_stat_database_tup_fetched{datname=~\"$datname\", pod=\"$instance\"}",
+          "expr": "cnpg_pg_stat_database_tup_fetched{datname=~\"$datname\", pod=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -3269,7 +3264,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "pg_stat_database_tup_inserted{datname=~\"$datname\", pod=\"$instance\"}",
+          "expr": "cnpg_pg_stat_database_tup_inserted{datname=~\"$datname\", pod=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -3383,7 +3378,7 @@
           "step": 2
         }
       ],
-      "title": "Lock tables",
+      "title": "Lock tables (NOT WORKING)",
       "type": "timeseries"
     },
     {
@@ -3479,7 +3474,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "pg_stat_database_tup_returned{datname=~\"$datname\", pod=\"$instance\"}",
+          "expr": "cnpg_pg_stat_database_tup_returned{datname=~\"$datname\", pod=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -3591,7 +3586,7 @@
           "step": 2
         }
       ],
-      "title": "Idle sessions",
+      "title": "Idle sessions (NOT WORKING)",
       "type": "timeseries"
     },
     {
@@ -3687,7 +3682,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "pg_stat_database_tup_deleted{datname=~\"$datname\", pod=\"$instance\"}",
+          "expr": "cnpg_pg_stat_database_tup_deleted{datname=~\"$datname\", pod=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -3790,7 +3785,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "pg_stat_database_blks_hit{pod=\"$instance\", datname=~\"$datname\"} / (pg_stat_database_blks_read{pod=\"$instance\", datname=~\"$datname\"} + pg_stat_database_blks_hit{pod=\"$instance\", datname=~\"$datname\"})",
+          "expr": "cnpg_pg_stat_database_blks_hit{pod=\"$instance\", datname=~\"$datname\"} / (cnpg_pg_stat_database_blks_read{pod=\"$instance\", datname=~\"$datname\"} + cnpg_pg_stat_database_blks_hit{pod=\"$instance\", datname=~\"$datname\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ datname }}",
@@ -3893,7 +3888,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "irate(pg_stat_bgwriter_buffers_backend_total{pod=\"$instance\"}[5m])",
+          "expr": "irate(cnpg_pg_stat_bgwriter_buffers_backend{pod=\"$instance\"}[5m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "buffers_backend",
@@ -3904,7 +3899,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "irate(pg_stat_bgwriter_buffers_alloc_total{pod=\"$instance\"}[5m])",
+          "expr": "irate(cnpg_pg_stat_bgwriter_buffers_alloc{pod=\"$instance\"}[5m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "buffers_alloc",
@@ -3915,7 +3910,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "irate(pg_stat_bgwriter_buffers_backend_fsync_total{pod=\"$instance\"}[5m])",
+          "expr": "irate(cnpg_pg_stat_bgwriter_buffers_backend_fsync{pod=\"$instance\"}[5m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "backend_fsync",
@@ -3926,7 +3921,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "irate(pg_stat_bgwriter_buffers_checkpoint_total{pod=\"$instance\"}[5m])",
+          "expr": "irate(cnpg_pg_stat_bgwriter_buffers_checkpoint{pod=\"$instance\"}[5m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "buffers_checkpoint",
@@ -3937,7 +3932,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "irate(pg_stat_bgwriter_buffers_clean_total{pod=\"$instance\"}[5m])",
+          "expr": "irate(cnpg_pg_stat_bgwriter_buffers_clean{pod=\"$instance\"}[5m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "buffers_clean",
@@ -4040,7 +4035,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "irate(pg_stat_database_conflicts{pod=\"$instance\", datname=~\"$datname\"}[5m])",
+          "expr": "irate(cnpg_pg_stat_database_conflicts{pod=\"$instance\", datname=~\"$datname\"}[5m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{datname}} conflicts",
@@ -4051,7 +4046,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "irate(pg_stat_database_deadlocks{pod=\"$instance\", datname=~\"$datname\"}[5m])",
+          "expr": "irate(cnpg_pg_stat_database_deadlocks{pod=\"$instance\", datname=~\"$datname\"}[5m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{datname}} deadlocks",
@@ -4155,7 +4150,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "irate(pg_stat_database_temp_bytes{pod=\"$instance\", datname=~\"$datname\"}[5m])",
+          "expr": "irate(cnpg_pg_stat_database_temp_bytes{pod=\"$instance\", datname=~\"$datname\"}[5m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{datname}}",
@@ -4168,7 +4163,7 @@
   ],
   "preload": false,
   "refresh": "15m",
-  "schemaVersion": 41,
+  "schemaVersion": 42,
   "tags": [
     "postgres",
     "db",
@@ -4190,18 +4185,19 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(pg_exporter_last_scrape_duration_seconds,namespace)",
+        "definition": "label_values(cnpg_collector_up,namespace)",
         "includeAll": false,
         "label": "Namespace",
         "name": "namespace",
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(pg_exporter_last_scrape_duration_seconds,namespace)",
+          "query": "label_values(cnpg_collector_up,namespace)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
         "regex": "",
+        "regexApplyTo": "value",
         "sort": 1,
         "type": "query"
       },
@@ -4211,18 +4207,19 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(pg_exporter_last_scrape_duration_seconds{namespace=\"$namespace\"},pod)",
+        "definition": "label_values(cnpg_collector_up{namespace=\"$namespace\"},pod)",
         "includeAll": false,
         "label": "Instance",
         "name": "instance",
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(pg_exporter_last_scrape_duration_seconds{namespace=\"$namespace\"},pod)",
+          "query": "label_values(cnpg_collector_up{namespace=\"$namespace\"},pod)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "sort": 1,
         "type": "query"
       },
@@ -4234,8 +4231,10 @@
             "$__all"
           ]
         },
-        "datasource": "${datasource}",
-        "definition": "label_values(pg_stat_database_tup_fetched{pod=\"$instance\"},datname)",
+        "datasource": {
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(cnpg_pg_stat_database_tup_fetched{pod=\"$instance\"},datname)",
         "includeAll": true,
         "label": "Database",
         "multi": true,
@@ -4243,11 +4242,12 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(pg_stat_database_tup_fetched{pod=\"$instance\"},datname)",
+          "query": "label_values(cnpg_pg_stat_database_tup_fetched{pod=\"$instance\"},datname)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "sort": 1,
         "type": "query"
       },
@@ -4259,7 +4259,9 @@
             "$__all"
           ]
         },
-        "datasource": "${datasource}",
+        "datasource": {
+          "uid": "${datasource}"
+        },
         "definition": "",
         "includeAll": true,
         "label": "Lock table",
@@ -4269,6 +4271,7 @@
         "query": "label_values({mode=~\"accessexclusivelock|accesssharelock|exclusivelock|rowexclusivelock|rowsharelock|sharelock|sharerowexclusivelock|shareupdateexclusivelock\"}, mode)",
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "type": "query"
       }
     ]
@@ -4290,6 +4293,8 @@
     ]
   },
   "timezone": "default",
-  "title": "Postgres overview",
-  "uid": "postgres"
+  "title": "Postgres overview - CNPG",
+  "uid": "postgres",
+  "version": 4,
+  "weekStart": ""
 }


### PR DESCRIPTION
This update changes the Postgres Overview dashboard to be CNPG specific.
The Zalando-version is lost, as it is overwritten by this file.

Should hold off on merging until we open up for CNPG databases.